### PR TITLE
Address PR #57 review feedback + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+FAIR Forge is a modular toolchain for building, validating, and federating WordPress (and eventually other) packages under the FAIR Protocol. It is a collection of composable tools — not a single monolith. The immediate focus is on static checks for WordPress plugins.
+
+**License constraint:** This project uses MIT. Any GPL-licensed code must live in a separate repository and be consumed as an external service — it must not be integrated here.
+
+## Repository Structure
+
+```
+tools/wordpress/
+  shared/                        # Shared base classes used by all tools
+  static-checks-contact-info/    # Checks publisher contact headers
+  static-checks-support-info/    # Checks support information
+  static-checks-security-info/   # Checks security contact headers
+  static-checks-phpcs/           # Runs PHPCS on plugin code
+  static-checks-php-min-max/     # Checks PHP version compatibility
+toolbox-docs/                    # Architecture and specification docs
+tools/sbom-tools/                # Shell scripts for SBOM generation/scanning
+tools/sentinel-shell/            # Shell scripts for file integrity checks
+```
+
+Each tool under `tools/wordpress/` is a standalone Composer package with its own `composer.json`, `phpcs.xml`, `phpunit.xml.dist`, `src/`, `tests/`, and a CLI entry point in `bin/`.
+
+## Architecture: Scanner + Result Pattern
+
+Every WordPress static-check tool follows the same pattern:
+
+1. **Scanner** (`*Scanner.php`) extends `AbstractToolScanner` from `fair-forge/shared`. Subclasses only implement `getToolName(): string` and `scanDirectory(string $directory): ToolResultInterface`. The base class handles URL download, ZIP extraction, and dispatch.
+
+2. **Result** (`*Result.php`) extends `AbstractToolResult` from `fair-forge/shared`. Must implement `getToolName()`, `isSuccess()`, `getSummary()`, `getData()`, `getIssues()`, and `getMetadata()`. The base class assembles a standard JSON envelope automatically via `toArray()` / `toJson()` / `saveToFile()`.
+
+3. **Standard JSON envelope** output by every tool:
+   ```json
+   {
+     "schema_version": "1.0.0",
+     "tool": "<slug>",
+     "success": true,
+     "summary": {},
+     "data": {},
+     "issues": [],
+     "metadata": { "scanned_at": "ISO-8601" }
+   }
+   ```
+
+`ScanTarget` accepts three input types: `Url`, `ZipFile`, or `Directory`. The scanner's `scan()` method dispatches accordingly.
+
+Plugin metadata (headers, readme.txt) is parsed via `fairpm/did-manager` through the shared `PluginMetadataReader` class.
+
+## Commands
+
+Each tool and the shared package are developed independently. Run these from within the tool's directory after `composer install`.
+
+```bash
+# Install dependencies
+composer install
+
+# Run tests
+composer test
+# or directly:
+vendor/bin/phpunit
+
+# Run a single test file
+vendor/bin/phpunit tests/ContactInfoScannerTest.php
+
+# Lint
+composer lint
+
+# Lint + fix
+composer lint:fix
+
+# Lint + test together (where available)
+composer check
+```
+
+## Adding a New WordPress Static-Check Tool
+
+1. Create a new directory under `tools/wordpress/static-checks-<name>/`.
+2. Set up `composer.json` with a path repository pointing to `../shared` and requiring `fair-forge/shared: @dev`.
+3. Implement `<Name>Scanner extends AbstractToolScanner` — only `getToolName()` and `scanDirectory()` are required.
+4. Implement `<Name>Result extends AbstractToolResult` — implement the six abstract methods; `toArray()` / `toJson()` / `saveToFile()` come for free.
+5. Add a CLI entry point in `bin/` and register it in `composer.json` under `"bin"`.
+6. Mirror the `phpcs.xml`, `phpunit.xml.dist`, and `scripts` block from an existing tool.

--- a/tools/package-profiler/output-schema-example.json
+++ b/tools/package-profiler/output-schema-example.json
@@ -87,9 +87,9 @@
       }
     ],
     "risk_assessment": {
-      "weighted_risk":   324,
+      "weighted_risk":   202.5,
       "cvss_critical":   0,
-      "cvss_high":       324,
+      "cvss_high":       8.1,
       "cvss_medium":     0,
       "cvss_low":        0,
       "cvss_negligible": 0,
@@ -103,10 +103,10 @@
         "total":       1
       },
       "scoring_notes": {
-        "method":          "weighted_cvss",
-        "cvss_version":    "3.1",
+        "method":          "cvss_weighted",
+        "cvss_version":    "3.1_preferred",
         "unscored_vulns":  0,
-        "weights":         { "critical": 1000, "high": 324, "medium": 81, "low": 9, "negligible": 1 }
+        "weights":         "Critical×100 High×25 Medium×5 Low×1 Negligible×0.1"
       }
     }
   },

--- a/tools/package-profiler/sbom-gen.sh
+++ b/tools/package-profiler/sbom-gen.sh
@@ -161,29 +161,25 @@ sanitize_name() {
     echo "$clean"
 }
 
+# _is_hash_version VALUE
+# Returns 0 (true) if VALUE looks like a content hash rather than a version string.
+# Syft uses SHA256 hashes as metadata.component.version when no semantic version
+# can be determined from archive contents.
+_is_hash_version() {
+    local v="$1"
+    # Bare hex hash (32+ chars, upper or lower): raw SHA-256/SHA-512 hex
+    [[ ${#v} -ge 32 ]] && [[ "$v" =~ ^[0-9a-fA-F]+$ ]] && return 0
+    # Digest-prefixed form: "sha256:abcdef...", "sha512:...", "md5:..."
+    [[ "$v" =~ ^(sha256|sha512|sha384|sha1|md5)[_:][0-9a-fA-F]{16,}$ ]] && return 0
+    return 1
+}
+
 # extract_version_from_sbom FILE
 # Reads a generated SPDX or CycloneDX JSON and returns the root package version.
 # Returns empty string if not found — callers must handle the empty case.
 extract_version_from_sbom() {
     local file="$1"
     local ver=""
-
-    # Helper: reject values that look like content hashes rather than version strings.
-    # Syft uses the file's SHA256 hash as metadata.component.version when it cannot
-    # determine a semantic version from the archive contents. A real version number
-    # always contains a digit followed by a non-hex character (dot, dash, letter beyond
-    # a-f) or is short enough that it cannot be a full hash. A 32+ character string
-    # composed entirely of lowercase hex digits is always a hash, never a version.
-    _is_hash_version() {
-        local v="$1"
-        # Bare hex hash (32+ chars, upper or lower): raw SHA-256/SHA-512 hex
-        [[ ${#v} -ge 32 ]] && [[ "$v" =~ ^[0-9a-fA-F]+$ ]] && return 0
-        # Digest-prefixed form: "sha256:abcdef...", "sha512:...", "md5:..."
-        # Syft sets metadata.component.version to this OCI digest format for
-        # archive/directory targets when no semantic version can be determined.
-        [[ "$v" =~ ^(sha256|sha512|sha384|sha1|md5)[_:][0-9a-fA-F]{16,}$ ]] && return 0
-        return 1
-    }
 
     # CycloneDX: metadata.component.version
     ver=$(jq -r '.metadata.component.version // ""' "$file" 2>/dev/null || echo "")
@@ -646,6 +642,9 @@ if [[ "$SUCCESS" == "true" ]]; then
     if [[ "$WRITE_FILES" == "true" ]]; then
         [[ "$OUTPUT_FORMAT" =~ (both|spdx) ]]      && log "    SPDX:      $(basename "$SPDX_FILE")"
         [[ "$OUTPUT_FORMAT" =~ (both|cyclonedx) ]] && log "    CycloneDX: $(basename "$CDX_FILE")"
+    fi
+    if [[ "$JSON_OUTPUT" == "true" && -n "${PROV_FILE:-}" && -f "$PROV_FILE" ]]; then
+        jq '.' "$PROV_FILE"
     fi
     exit 0
 else

--- a/tools/package-profiler/vuln-scan-risk.jq
+++ b/tools/package-profiler/vuln-scan-risk.jq
@@ -8,7 +8,7 @@
 # }
 #
 # Weights: Critical×100, High×25, Medium×5, Low×1, Negligible×0.1
-# CVSS preference: 3.1 > 3.0 > 2.0 > first available
+# CVSS preference: 3.1 > 3.0 > first available with a non-null version
 
 [.matches[] |
     {

--- a/tools/package-profiler/vuln-scan.sh
+++ b/tools/package-profiler/vuln-scan.sh
@@ -38,8 +38,9 @@ INPUT_TARGET=""             # SBOM file, archive, or directory
 
 # ── Cleanup trap ─────────────────────────────────────────────────────────────
 
+TMPDIR_WORK=""
 cleanup() {
-    rm -f /tmp/vuln_scan_*.json /tmp/vuln_final_*.json 2>/dev/null || true
+    [[ -n "$TMPDIR_WORK" && -d "$TMPDIR_WORK" ]] && rm -rf "$TMPDIR_WORK"
 }
 trap cleanup EXIT INT TERM
 
@@ -129,7 +130,7 @@ die()  { echo "Error: $*" >&2; exit 2; }
 
 check_dependencies() {
     local missing=()
-    for cmd in grype jq; do
+    for cmd in grype jq timeout bc; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
     if [[ ${#missing[@]} -gt 0 ]]; then
@@ -331,7 +332,9 @@ log "[SCAN] Scanning '$(basename "$INPUT_TARGET")' for vulnerabilities..."
     && log "       DB age: ${DB_AGE_HOURS}h" \
     || log "       (First run may be slow while Grype initialises its database)"
 
-TMP_VULN=$(mktemp -t vuln_scan_XXXXXX.json)
+TMPDIR_WORK=$(mktemp -d "${TMPDIR:-/tmp}/vuln-scan.XXXXXX") \
+    || { echo "Error: Cannot create temp directory" >&2; exit 2; }
+TMP_VULN="$TMPDIR_WORK/vuln_scan.json"
 
 grype_status=0
 declare -a grype_cmd=(grype "$GRYPE_SCHEME" -o json)
@@ -365,7 +368,7 @@ RISK_LEVEL="LOW"
 
 if [[ "$CALCULATE_RISK" == "true" ]]; then
     # Capture stderr separately so a jq error message is visible, not silenced
-    risk_stderr=$(mktemp -t vuln_risk_err_XXXXXX.txt)
+    risk_stderr="$TMPDIR_WORK/risk_stderr.txt"
     risk_exit=0
     RISK_DATA=$(calculate_risk_score "$TMP_VULN" "$JQ_FILE" 2>"$risk_stderr") \
         || risk_exit=$?
@@ -384,8 +387,6 @@ if [[ "$CALCULATE_RISK" == "true" ]]; then
             scoring_notes: {method:"failed", weights:"", unscored_vulns:0, cvss_version:""}
         }')
     fi
-    rm -f "$risk_stderr" 2>/dev/null || true
-
     RISK_SCORE=$(echo "$RISK_DATA" | jq -r '.weighted_risk // 0')
     RISK_LEVEL=$(risk_level_label "$RISK_SCORE")
     info "Weighted risk score: $RISK_SCORE ($RISK_LEVEL)"
@@ -442,7 +443,7 @@ case "$OUTPUT_FORMAT" in
 
     # ── merged: SBOM + vulnerability data + risk assessment (default) ────────
     merged)
-        TMP_FINAL=$(mktemp -t vuln_final_XXXXXX.json)
+        TMP_FINAL="$TMPDIR_WORK/vuln_final.json"
 
         # Build the risk_assessment block with a consistent schema
         RISK_BLOCK=$(jq -n \


### PR DESCRIPTION
## Summary

Follow-up to #57 — applies review fixes that were committed after the PR was merged, plus adds the project CLAUDE.md.

- `vuln-scan.sh`: replace hardcoded `/tmp` glob cleanup with a single temp dir; all temp files live inside it and are wiped via `rm -rf` in the trap (fixes macOS temp dir leakage per Chuck Adams' review comment)
- `vuln-scan.sh`: add `timeout` and `bc` to `check_dependencies()` so missing tools are caught at preflight rather than mid-run
- `sbom-gen.sh`: move `_is_hash_version()` to top level; was nested inside `extract_version_from_sbom()` but called from outside
- `sbom-gen.sh`: implement `-j/--json` — emits provenance block as JSON to stdout after generation (was parsed but never acted on)
- `vuln-scan-risk.jq`: correct CVSS preference comment; no explicit 2.0 step exists in the code
- `output-schema-example.json`: fix `cvss_high` (8.1, not 324), `weighted_risk` (202.5 = 8.1×25), and `scoring_notes` fields to match actual jq output
- `CLAUDE.md`: add project instructions for Claude Code

## Test plan

- [ ] Verify `vuln-scan.sh` cleanup trap removes temp dir on exit
- [ ] Verify `vuln-scan.sh` exits cleanly with missing `timeout` or `bc`
- [ ] Verify `sbom-gen.sh -j` emits provenance block to stdout
- [ ] Verify `output-schema-example.json` values are consistent with `vuln-scan-risk.jq` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)